### PR TITLE
Migrate release workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,196 +5,29 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   attestations: write
 
-env:
-  VERSION: ${{ github.event.release.tag_name }}
-
 jobs:
-  publish-crates-io:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: release
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
-        with:
-          toolchain: 1.88.0
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-
-      - uses: inference-labs-inc/set-toml-version@ff9a4b64df4ce91067737822d2811a69597bf688 # v1
-        with:
-          version: ${{ github.event.release.tag_name }}
-          files: crates/btlightning/Cargo.toml
-
-      - name: Verify only version fields changed
-        run: |
-          git diff --name-only | sort > /tmp/changed.txt
-          echo "crates/btlightning/Cargo.toml" | sort > /tmp/expected.txt
-          diff /tmp/changed.txt /tmp/expected.txt
-
-      - name: Package btlightning
-        run: cargo package -p btlightning --all-features --allow-dirty
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-path: target/package/btlightning-*.crate
-
-      - name: Authenticate with crates.io
-        id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
-
-      - name: Publish btlightning
-        run: cargo publish -p btlightning --all-features --allow-dirty
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-
-  build-wheels:
-    name: Build wheels - ${{ matrix.os }} ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64
-            zig: false
-          - os: ubuntu-latest
-            target: aarch64
-            zig: true
-          - os: macos-14
-            target: aarch64
-            zig: false
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: inference-labs-inc/set-toml-version@ff9a4b64df4ce91067737822d2811a69597bf688 # v1
-        with:
-          version: ${{ github.event.release.tag_name }}
-          files: |
-            crates/btlightning/Cargo.toml
-            crates/btlightning-py/Cargo.toml
-            crates/btlightning-py/pyproject.toml
-
-      - name: Verify only version fields changed
-        run: |
-          git diff --name-only | sort > /tmp/changed.txt
-          printf 'crates/btlightning-py/Cargo.toml\ncrates/btlightning-py/pyproject.toml\ncrates/btlightning/Cargo.toml\n' | sort > /tmp/expected.txt
-          diff /tmp/changed.txt /tmp/expected.txt
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.12"
-
-      - name: Build wheels
-        uses: PyO3/maturin-action@b1bd829e37fef14c63f19162034228a2f3dc1021 # v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist ${{ matrix.zig && '--zig' || '' }} ${{ matrix.target == 'aarch64' && matrix.os == 'ubuntu-latest' && '-i python3.12' || '' }}
-          container: "off"
-          working-directory: crates/btlightning-py
-        env:
-          RUSTFLAGS: ${{ startsWith(matrix.os, 'macos') && '-C link-arg=-undefined -C link-arg=dynamic_lookup' || '' }}
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: wheels-${{ matrix.os }}-${{ matrix.target }}
-          path: crates/btlightning-py/dist
-
-  build-sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: inference-labs-inc/set-toml-version@ff9a4b64df4ce91067737822d2811a69597bf688 # v1
-        with:
-          version: ${{ github.event.release.tag_name }}
-          files: |
-            crates/btlightning/Cargo.toml
-            crates/btlightning-py/Cargo.toml
-            crates/btlightning-py/pyproject.toml
-
-      - name: Verify only version fields changed
-        run: |
-          git diff --name-only | sort > /tmp/changed.txt
-          printf 'crates/btlightning-py/Cargo.toml\ncrates/btlightning-py/pyproject.toml\ncrates/btlightning/Cargo.toml\n' | sort > /tmp/expected.txt
-          diff /tmp/changed.txt /tmp/expected.txt
-
-      - name: Build sdist
-        uses: PyO3/maturin-action@b1bd829e37fef14c63f19162034228a2f3dc1021 # v1
-        with:
-          command: sdist
-          args: --out dist
-          working-directory: crates/btlightning-py
-
-      - name: Upload sdist
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: sdist
-          path: crates/btlightning-py/dist
-
-  upload-release-assets:
-    name: Upload release assets
-    needs: [build-wheels, build-sdist]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+  release:
+    uses: inference-labs-inc/release/.github/workflows/publish-release.yml@main
+    with:
+      version: ${{ github.event.release.tag_name }}
+      rust-toolchain: "1.88.0"
+      version-files: |
+        crates/btlightning/Cargo.toml
+        crates/btlightning-py/Cargo.toml
+        crates/btlightning-py/pyproject.toml
+      maturin-working-directory: crates/btlightning-py
+      test-import: "from btlightning import Lightning"
+      publish-crates-io: true
+      crate-name: btlightning
+      crate-features: "--all-features"
+      crate-version-files: "crates/btlightning/Cargo.toml"
+      slsa-attestation: true
+    secrets: inherit
     permissions:
       contents: write
-    steps:
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-
-      - name: Download sdist
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          name: sdist
-          path: dist
-
-      - name: Upload assets to GitHub Release
-        run: gh release upload "$VERSION" dist/* --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-
-  publish-pypi:
-    name: Publish to PyPI
-    needs: [build-wheels, build-sdist]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: release
-    permissions:
       id-token: write
-    steps:
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: true
-
-      - name: Download sdist
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
-        with:
-          name: sdist
-          path: dist
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
-        with:
-          packages-dir: dist/
-          attestations: true
+      attestations: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    uses: inference-labs-inc/release/.github/workflows/publish-release.yml@main
+    uses: inference-labs-inc/release/.github/workflows/publish-release.yml@c8fedc682daa107a820a5bc1fbd03b95ff428421
     with:
       version: ${{ github.event.release.tag_name }}
       rust-toolchain: "1.88.0"


### PR DESCRIPTION
## Summary
- Replace standalone 150+ line release workflow with thin caller to `inference-labs-inc/release/.github/workflows/publish-release.yml`
- Standardizes version injection (`set-toml-version` action), manylinux 2_28 wheel builds, Sigstore PyPI attestations, and platform coverage
- All existing capabilities preserved: crates.io publish, SLSA attestation, sdist, linux aarch64 cross-compile, GitHub Release assets
- Gains wheel smoke testing (not previously present)

## Downstream dependency
Requires [inference-labs-inc/release#4](https://github.com/inference-labs-inc/release/pull/4) to merge first. The `@main` ref should be updated to a SHA pin before merging this PR.

## Manual steps before merge
- Verify PyPI trusted publisher is configured for the reusable workflow path (`inference-labs-inc/release/.github/workflows/publish-release.yml`)