### PR TITLE
Resolve insufficient permissions for audit check run creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2


### PR DESCRIPTION
## Summary
- Adds job-level `checks: write` permission to the `audit` job so `rustsec/audit-check` can create GitHub Check Runs
- Scoped to the audit job only — all other jobs inherit the workflow-level `contents: read` restriction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow security audit permissions to improve repository access and check-based automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->