### PR TITLE
Resolve RUSTSEC-2026-0049 rustls-webpki CRL matching vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8743,9 +8743,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Upgrades `rustls-webpki` from 0.103.9 to 0.103.10 to resolve RUSTSEC-2026-0049 (faulty CRL Distribution Point matching)
- RUSTSEC-2026-0037 (`quinn-proto` DoS) was already resolved in #54

Only `Cargo.lock` is modified; no source changes. The patched version is within semver-compatible range, pulled via `cargo update rustls-webpki@0.103.9`.

## Verification

- `cargo audit` confirms neither RUSTSEC-2026-0037 nor RUSTSEC-2026-0049 appear
- `cargo clippy --workspace -- -D warnings` passes clean
- `cargo fmt --check` passes