### PR TITLE
Resolve QUIC reassembly and PyO3 advisory exposure (quinn-proto 0.11.15, pyo3 0.29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,15 +2101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,15 +2496,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "merlin"
@@ -3099,35 +3081,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3135,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3147,13 +3126,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -5134,12 +5112,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom 0.14.1",

--- a/crates/btlightning-py/Cargo.toml
+++ b/crates/btlightning-py/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 btlightning = { path = "../btlightning", features = ["btwallet"] }
-pyo3 = { version = "0.26", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 tokio = { version = "1.0", features = ["full"] }
 rmpv = { version = "1", features = ["with-serde"] }
 async-trait = "0.1"
@@ -23,4 +23,4 @@ async-trait = "0.1"
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
-pyo3-build-config = "0.26"
+pyo3-build-config = "0.29"

--- a/crates/btlightning-py/src/handler.rs
+++ b/crates/btlightning-py/src/handler.rs
@@ -37,13 +37,13 @@ impl SynapseHandler for PythonSynapseHandler {
 
             let result_bound = result.bind(py);
             let result_dict = result_bound
-                .downcast::<PyDict>()
+                .cast::<PyDict>()
                 .map_err(|e| LightningError::Handler(e.to_string()))?;
 
             let mut response_data = HashMap::new();
             for (key, value) in result_dict.iter() {
                 let key_str: String = key
-                    .extract()
+                    .extract::<String>()
                     .map_err(|e| LightningError::Handler(e.to_string()))?;
                 let value_msgpack = py_to_msgpack_value(&value)
                     .map_err(|e| LightningError::Handler(e.to_string()))?;
@@ -172,7 +172,7 @@ pub fn py_to_msgpack_value(value: &Bound<'_, pyo3::PyAny>) -> PyResult<rmpv::Val
         Ok(rmpv::Value::Integer(rmpv::Integer::from(i)))
     } else if let Ok(u) = value.extract::<u64>() {
         Ok(rmpv::Value::Integer(rmpv::Integer::from(u)))
-    } else if value.downcast::<PyInt>().is_ok() {
+    } else if value.cast::<PyInt>().is_ok() {
         Err(pyo3::exceptions::PyOverflowError::new_err(
             "integer too large for msgpack representation (must fit i64 or u64)",
         ))
@@ -180,13 +180,13 @@ pub fn py_to_msgpack_value(value: &Bound<'_, pyo3::PyAny>) -> PyResult<rmpv::Val
         Ok(rmpv::Value::F64(f))
     } else if let Ok(s) = value.extract::<String>() {
         Ok(rmpv::Value::String(rmpv::Utf8String::from(s.as_str())))
-    } else if let Ok(list) = value.downcast::<PyList>() {
+    } else if let Ok(list) = value.cast::<PyList>() {
         let mut arr = Vec::new();
         for item in list.iter() {
             arr.push(py_to_msgpack_value(&item)?);
         }
         Ok(rmpv::Value::Array(arr))
-    } else if let Ok(dict) = value.downcast::<PyDict>() {
+    } else if let Ok(dict) = value.cast::<PyDict>() {
         let mut entries = Vec::new();
         for (k, v) in dict.iter() {
             entries.push((py_to_msgpack_value(&k)?, py_to_msgpack_value(&v)?));

--- a/crates/btlightning-py/src/types.rs
+++ b/crates/btlightning-py/src/types.rs
@@ -1,7 +1,7 @@
 use btlightning::types::QuicAxonInfo as CoreQuicAxonInfo;
 use pyo3::prelude::*;
 
-#[pyclass(name = "QuicAxonInfo")]
+#[pyclass(name = "QuicAxonInfo", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyQuicAxonInfo {
     #[pyo3(get, set)]

--- a/crates/btlightning/Cargo.toml
+++ b/crates/btlightning/Cargo.toml
@@ -14,7 +14,7 @@ name = "btlightning"
 
 [dependencies]
 quinn = "0.11"
-quinn-proto = "0.11.14"
+quinn-proto = "0.11.15"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging"] }
 rcgen = "0.13"
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Two dependency security remediations for btlightning.

1. quinn-proto 0.11.14 -> 0.11.15 (RUSTSEC-2026-0185): caps unbounded out-of-order QUIC stream reassembly a remote peer could use to exhaust memory. Build verified; btlightning does not touch the changed Assembler API.

2. pyo3 0.26 -> 0.29.0 (RUSTSEC-2026-0176 / RUSTSEC-2026-0177): moves to the patched line rather than ignoring. Includes the 0.27-0.29 casting API migration (downcast -> cast), an explicit dict-key extract target, and pyclass(from_py_object) on PyQuicAxonInfo to preserve the FromPyObject derive. pyo3 0.29 drops indoc/unindent/memoffset.

Verified locally: cargo check, cargo clippy --workspace -- -D warnings, and cargo deny check advisories all clean (both advisory classes cleared).