### PR TITLE
Improve connection reuse routing consistency in query paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-bls12-377"

--- a/crates/btlightning/src/client.rs
+++ b/crates/btlightning/src/client.rs
@@ -548,14 +548,25 @@ impl LightningClient {
     ) -> Result<QuicResponse> {
         let addr_key = axon_info.addr_key();
 
-        let connection = {
+        let (connection, bound) = {
             let state = self.state.read().await;
-            state.registry.get_connection(&addr_key)
+            (
+                state.registry.get_connection(&addr_key),
+                state
+                    .registry
+                    .is_authenticated_at(&axon_info.hotkey, &addr_key),
+            )
         };
 
         let max_fp = self.config.max_frame_payload_bytes;
         match connection {
             Some(conn) if conn.close_reason().is_none() => {
+                if !bound {
+                    return Err(LightningError::Handshake(format!(
+                        "no authenticated route for {} at {}",
+                        axon_info.hotkey, addr_key
+                    )));
+                }
                 debug!(
                     addr = %addr_key,
                     stable_id = conn.stable_id(),
@@ -604,15 +615,26 @@ impl LightningClient {
     ) -> Result<StreamingResponse> {
         let addr_key = axon_info.addr_key();
 
-        let connection = {
+        let (connection, bound) = {
             let state = self.state.read().await;
-            state.registry.get_connection(&addr_key)
+            (
+                state.registry.get_connection(&addr_key),
+                state
+                    .registry
+                    .is_authenticated_at(&axon_info.hotkey, &addr_key),
+            )
         };
 
         let max_fp = self.config.max_frame_payload_bytes;
         let max_sp = self.config.max_stream_payload_bytes;
         match connection {
             Some(conn) if conn.close_reason().is_none() => {
+                if !bound {
+                    return Err(LightningError::Handshake(format!(
+                        "no authenticated route for {} at {}",
+                        axon_info.hotkey, addr_key
+                    )));
+                }
                 open_streaming_synapse(
                     &conn,
                     request,
@@ -852,6 +874,14 @@ impl LightningClient {
             miners,
         )
         .await
+    }
+
+    /// Returns the set of miner hotkeys that currently hold an active,
+    /// authenticated connection binding. Callers can use this to route work
+    /// only to peers whose identity has been confirmed on their connection.
+    pub async fn authenticated_hotkeys(&self) -> std::collections::HashSet<String> {
+        let state = self.state.read().await;
+        state.registry.active_hotkeys().into_iter().collect()
     }
 
     /// Returns a map of connection statistics (total connections, active miners, per-address status).

--- a/crates/btlightning/src/client.rs
+++ b/crates/btlightning/src/client.rs
@@ -876,9 +876,11 @@ impl LightningClient {
         .await
     }
 
-    /// Returns the set of miner hotkeys that currently hold an active,
-    /// authenticated connection binding. Callers can use this to route work
-    /// only to peers whose identity has been confirmed on their connection.
+    /// Returns the set of miner hotkeys that have completed the authentication
+    /// handshake and hold an active registry entry. A hotkey stays listed while
+    /// registered even if its connection is momentarily re-establishing, so
+    /// callers receive every peer whose identity has been confirmed, not only
+    /// those with a live connection at this instant.
     pub async fn authenticated_hotkeys(&self) -> std::collections::HashSet<String> {
         let state = self.state.read().await;
         state.registry.active_hotkeys().into_iter().collect()

--- a/crates/btlightning/src/registry.rs
+++ b/crates/btlightning/src/registry.rs
@@ -96,6 +96,17 @@ impl MinerRegistry {
         self.active_miners.contains_key(hotkey)
     }
 
+    /// Whether `hotkey` holds an active registry entry bound to `addr`. A live
+    /// connection at an address may be shared by several hotkeys, so connection
+    /// reuse must be confirmed against the hotkey's own registered address
+    /// rather than the address alone.
+    pub fn is_authenticated_at(&self, hotkey: &str, addr: &PeerAddr) -> bool {
+        self.active_miners
+            .get(hotkey)
+            .map(|m| m.addr_key() == *addr)
+            .unwrap_or(false)
+    }
+
     pub fn active_hotkeys(&self) -> Vec<String> {
         self.active_miners.keys().cloned().collect()
     }
@@ -349,5 +360,20 @@ mod tests {
         assert_eq!(reg.active_miner_count(), 0);
         assert_eq!(reg.reconnect_state_count(), 0);
         reg.assert_invariants();
+    }
+
+    #[test]
+    fn is_authenticated_at_matches_hotkey_and_address() {
+        let mut reg = MinerRegistry::new();
+        reg.register(QuicAxonInfo::new("hk1".into(), "1.2.3.4".into(), 8080, 4));
+        let addr = PeerAddr::new("1.2.3.4", 8080);
+        let other_addr = PeerAddr::new("5.6.7.8", 9090);
+
+        assert!(reg.is_authenticated_at("hk1", &addr));
+        // A hotkey with no registry entry is not bound to any address, even one
+        // another hotkey happens to hold a live connection at.
+        assert!(!reg.is_authenticated_at("hk2", &addr));
+        // A registered hotkey is only bound to its own registered address.
+        assert!(!reg.is_authenticated_at("hk1", &other_addr));
     }
 }


### PR DESCRIPTION
Routes reused QUIC connections through each hotkey's registered address in the miner registry, keeping query dispatch consistent with per-hotkey registration rather than address alone. Since a live connection at an address can be shared by multiple registered hotkeys, connection reuse now confirms the target hotkey's own registry binding before sending.

Adds a registry accessor (`is_authenticated_at`) and a client accessor (`authenticated_hotkeys`) for callers that need the confirmed hotkey set.

Covered by a registry unit test; existing suite passes, clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests now only use a connection if the selected miner hotkey is authenticated for that peer address.
  * When a route is not authenticated, the client returns a clear handshake error instead of continuing on an invalid connection.
  * Streaming and non-streaming requests now follow the same connection validation behavior.

* **New Features**
  * Added a way to view the set of currently authenticated miner hotkeys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->