### PR TITLE
Introduce explicit subtensor backend selection excluding archive RPC namespace

### DIFF
--- a/crates/btlightning/src/client.rs
+++ b/crates/btlightning/src/client.rs
@@ -23,9 +23,9 @@ use tokio::time::Instant;
 use tracing::{debug, error, info, instrument, warn};
 
 #[cfg(feature = "subtensor")]
-use crate::metagraph::{Metagraph, MetagraphMonitorConfig};
+use crate::metagraph::{connect_subtensor, Metagraph, MetagraphMonitorConfig};
 #[cfg(feature = "subtensor")]
-use subxt::{OnlineClient, PolkadotConfig};
+use subxt::PolkadotConfig;
 
 /// Configuration for [`LightningClient`].
 ///
@@ -968,7 +968,7 @@ impl LightningClient {
 
         let subtensor = tokio::time::timeout(
             Duration::from_secs(30),
-            OnlineClient::<PolkadotConfig>::from_url(&monitor_config.subtensor_endpoint),
+            connect_subtensor::<PolkadotConfig>(&monitor_config.subtensor_endpoint),
         )
         .await
         .map_err(|_| LightningError::Handler("subtensor connection timed out after 30s".into()))?
@@ -1059,7 +1059,7 @@ impl LightningClient {
                 if needs_reconnect {
                     match tokio::time::timeout(
                         Duration::from_secs(30),
-                        OnlineClient::<PolkadotConfig>::from_url(&subtensor_url),
+                        connect_subtensor::<PolkadotConfig>(&subtensor_url),
                     )
                     .await
                     {

--- a/crates/btlightning/src/lib.rs
+++ b/crates/btlightning/src/lib.rs
@@ -16,7 +16,8 @@ pub use client::{
 pub use error::{LightningError, Result};
 #[cfg(feature = "subtensor")]
 pub use metagraph::{
-    is_valid_ip, Metagraph, MetagraphMonitorConfig, NeuronInfo, FINNEY_ENDPOINT, TESTNET_ENDPOINT,
+    connect_subtensor, is_valid_ip, Metagraph, MetagraphMonitorConfig, NeuronInfo, FINNEY_ENDPOINT,
+    TESTNET_ENDPOINT,
 };
 pub use server::{
     typed_async_handler, typed_handler, AsyncSynapseHandler, HandshakeObserver, LightningServer,

--- a/crates/btlightning/src/metagraph.rs
+++ b/crates/btlightning/src/metagraph.rs
@@ -5,10 +5,13 @@ use parity_scale_codec::{Compact, Decode, Encode};
 use sp_core::crypto::Ss58Codec;
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 use std::time::Duration;
+use subxt::backend::{ChainHeadBackend, CombinedBackend, LegacyBackend};
 use subxt::client::{OnlineClientAtBlock, OnlineClientAtBlockImpl};
 use subxt::dynamic::Value;
 use subxt::ext::scale_value::At;
+use subxt::rpcs::RpcClient;
 use subxt::storage::StorageClient;
 use subxt::{OnlineClient, PolkadotConfig};
 use tracing::{debug, info, warn};
@@ -37,6 +40,49 @@ fn format_ipv4(ip_raw: u128, ip_type: u8) -> String {
 pub const FINNEY_ENDPOINT: &str = "wss://entrypoint-finney.opentensor.ai:443";
 /// WebSocket endpoint for the Bittensor testnet subtensor node.
 pub const TESTNET_ENDPOINT: &str = "wss://test.finney.opentensor.ai:443";
+
+/// Open a subxt [`OnlineClient`] against `endpoint`. `wss://` URLs use the
+/// TLS-validating constructor; `ws://` URLs use the insecure one, which subxt
+/// requires for non-TLS sockets even when reaching localhost or a private
+/// substrate node.
+///
+/// The backend is assembled explicitly rather than via
+/// `OnlineClient::from_url`, which builds a `CombinedBackend` that enables the
+/// `archive_v1_*` backend whenever the node advertises those methods in
+/// `rpc_methods`. Pruned subtensor nodes advertise the archive namespace but
+/// answer every archive call with `Method not found (-32601)`, and the archive
+/// backend builds its storage streams lazily, so the failure surfaces on first
+/// poll rather than at construction and `CombinedBackend`'s per-call fallback
+/// chain never gets the chance to retry against `chainHead` or the legacy
+/// `state_*` methods. Omitting the archive backend keeps storage reads on the
+/// two backends every subtensor node actually serves.
+pub async fn connect_subtensor<T: subxt::Config + Default>(
+    endpoint: &str,
+) -> Result<OnlineClient<T>> {
+    let rpc_client = if endpoint.starts_with("ws://") {
+        RpcClient::from_insecure_url(endpoint).await
+    } else {
+        RpcClient::from_url(endpoint).await
+    }
+    .map_err(|e| LightningError::Connection(format!("connecting to subtensor {endpoint}: {e}")))?;
+
+    let chain_head = ChainHeadBackend::builder().build_with_background_driver(rpc_client.clone());
+    let legacy = LegacyBackend::builder().build(rpc_client.clone());
+
+    let backend = CombinedBackend::<T>::builder()
+        .no_default_backends()
+        .with_chainhead_backend(chain_head)
+        .with_legacy_backend(legacy)
+        .build_with_background_driver(rpc_client)
+        .await
+        .map_err(|e| {
+            LightningError::Connection(format!("building subtensor backend for {endpoint}: {e}"))
+        })?;
+
+    OnlineClient::<T>::from_backend(Arc::new(backend))
+        .await
+        .map_err(|e| LightningError::Connection(format!("connecting to subtensor {endpoint}: {e}")))
+}
 
 #[derive(Decode)]
 struct AxonInfoRaw {

--- a/crates/btlightning/tests/localnet.rs
+++ b/crates/btlightning/tests/localnet.rs
@@ -63,13 +63,16 @@ async fn submit_extrinsic<Call: subxt::tx::Payload>(
     .unwrap_or_else(|_| panic!("{label} submission timed out after 30s"))
     .unwrap_or_else(|e| panic!("{label} submission failed: {e}"));
 
-    tokio::time::timeout(
+    match tokio::time::timeout(
         Duration::from_secs(60),
         progress.wait_for_finalized_success(),
     )
     .await
-    .unwrap_or_else(|_| panic!("{label} finalization timed out after 60s"))
-    .unwrap_or_else(|e| panic!("{label} finalization failed: {e}"));
+    {
+        Err(_) => panic!("{label} finalization timed out after 60s"),
+        Ok(Err(e)) => panic!("{label} finalization failed: {e}"),
+        Ok(Ok(_)) => {}
+    }
 }
 
 async fn query_total_networks(api: &OnlineClient<PolkadotConfig>) -> u16 {
@@ -91,7 +94,7 @@ async fn query_total_networks(api: &OnlineClient<PolkadotConfig>) -> u16 {
 #[tokio::test]
 #[ignore]
 async fn localnet_full_integration() {
-    let api = OnlineClient::<PolkadotConfig>::from_url(LOCALNET_ENDPOINT)
+    let api = btlightning::connect_subtensor::<PolkadotConfig>(LOCALNET_ENDPOINT)
         .await
         .expect("subtensor localnet must be reachable at ws://127.0.0.1:9944");
 

--- a/crates/btlightning/tests/subtensor.rs
+++ b/crates/btlightning/tests/subtensor.rs
@@ -6,7 +6,7 @@ use btlightning::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
-use subxt::{dynamic::Value, OnlineClient, SubstrateConfig};
+use subxt::{dynamic::Value, SubstrateConfig};
 
 const TESTNET_ENDPOINT: &str = "wss://test.finney.opentensor.ai:443";
 const PERMIT_POPULATION_TIMEOUT: Duration = Duration::from_secs(300);
@@ -22,7 +22,7 @@ impl SubtensorPermitResolver {
     }
 
     async fn resolve_async(&self) -> Result<HashSet<String>> {
-        let api = OnlineClient::<SubstrateConfig>::from_url(&self.rpc_url)
+        let api = btlightning::connect_subtensor::<SubstrateConfig>(&self.rpc_url)
             .await
             .map_err(|e| LightningError::Handler(format!("subtensor connection: {}", e)))?;
 


### PR DESCRIPTION
Companion to inference-labs-inc/subnet-2#608, which carries the same defect and the same reasoning.

## Investigation

`Metagraph::sync` fails against every mainnet subtensor entrypoint:

```
handler error: Cannot fetch the storage value: Backend error: RPC error: RPC error: User error: Method not found (-32601)
```

The failing request is the first storage read of the sync:

```json
{"method":"archive_v1_storage","params":["0x0fb6...736e",[{"key":"0x658faa38...0200","type":"value"}],null]}
```

Probing the endpoints directly shows the split:

| Endpoint | `archive_v1_storage` |
| --- | --- |
| `wss://entrypoint-finney.opentensor.ai:443` | `-32601 Method not found` |
| `wss://lite.chain.opentensor.ai:443` | `-32601 Method not found` |
| `wss://test.finney.opentensor.ai:443` | works |
| `wss://archive.chain.opentensor.ai:443` | works |

Every node advertises the full `archive_v1_*` namespace in `rpc_methods`, but only true archive nodes serve it. Pruned nodes list the methods and then reject each call. The `subtensor-tests` integration suite points at testnet, which is archive-backed, so nothing here caught it.

## Root cause

`OnlineClient::from_url` builds a `CombinedBackend`, which decides which sub-backends to enable purely from the advertised method list:

```rust
let has_archive_methods = methods.iter().any(|m| m.starts_with("archive_v1_"));
```

`CombinedBackend` does carry a per-call fallback chain (`archive` then `chainHead` then `legacy`), and it works for block headers and runtime calls. Storage is the exception: `ArchiveBackend::storage_fetch_values` constructs `ArchiveStorageStream` lazily and returns `Ok(stream)` without issuing any RPC, so `try_backends` records a success and never tries the other two backends. The `-32601` only appears when the caller polls the stream, past the point where a fallback could happen.

So the archive backend is chosen on evidence that is wrong for pruned nodes, and the one code path where that matters is also the one the fallback cannot cover.

## Change

Add `connect_subtensor<T: Config + Default>(endpoint)`, exported from the crate root under the existing `subtensor` feature, which assembles the backend explicitly and keeps only `chainHead` and `legacy`:

```rust
let chain_head = ChainHeadBackend::builder().build_with_background_driver(rpc_client.clone());
let legacy = LegacyBackend::builder().build(rpc_client.clone());

let backend = CombinedBackend::<T>::builder()
    .no_default_backends()
    .with_chainhead_backend(chain_head)
    .with_legacy_backend(legacy)
    .build_with_background_driver(rpc_client)
    .await?;
```

`CombinedBackend::build` still gates `chainHead` on the node advertising `chainHead_v1_*`, so a node offering only the legacy `state_*` methods degrades to legacy exactly as before. Both metagraph-monitor connection sites in `client.rs` (initial connect and reconnect-after-sync-failure) route through the helper, as do the two integration tests.

The helper also picks the insecure constructor for `ws://` endpoints. `localnet.rs` called `from_url("ws://127.0.0.1:9944")`, which subxt rejects outright with `InsecureUrl`; the test is `#[ignore]`d, so that never surfaced. It now goes through the same path as everything else.

Separately, `cargo clippy --all-targets --all-features -- -D warnings` was already failing on `main` with `result_large_err` in `localnet.rs`, where a closure passed to `unwrap_or_else` returns the 232-byte `TransactionFinalizedSuccessError`. Matching on the timeout result instead clears it.

## Verification

Metagraph sync against both networks through the new helper:

```
OK wss://entrypoint-finney.opentensor.ai:443 block=8715573 n=256 neurons=256
OK wss://test.finney.opentensor.ai:443 block=7653408 n=107 neurons=107
```

The same sync against mainnet through `OnlineClient::from_url`, for contrast:

```
FAILED: handler error: Cannot fetch the storage value: Backend error: RPC error: RPC error: User error: Method not found (-32601)
```

`cargo test -p btlightning --all-features` passes (111 + 51 + 13 unit and integration tests, network-gated suites ignored as usual). `cargo fmt --check` and `cargo clippy -p btlightning --all-targets --all-features -- -D warnings` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Subtensor connectivity and reconnection reliability across supported RPC endpoints.
  - Enhanced local network test handling to report connection, timeout, and finalization outcomes more clearly.

- **Tests**
  - Updated integration tests to use the unified Subtensor connection flow.
  - Preserved existing validator-permission and storage resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->