### PR TITLE
Resolve hotkey loading failures from keyfile crypto type and passphrase handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "btwallet"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbd26f85078c02aa02c7913494602afb5b994580ab8581682c40a9c7361ffad"
+checksum = "8365dd736f1a158d7a84cf31c659f15c1060326e8a80364de9a0ed1439f5d357"
 dependencies = [
  "ansible-vault",
  "base64 0.22.1",

--- a/crates/btlightning/Cargo.toml
+++ b/crates/btlightning/Cargo.toml
@@ -28,7 +28,7 @@ base64 = "0.22"
 indexmap = "2"
 rand = "0.8"
 sp-core = "34.0"
-bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false, optional = true }
+bittensor_wallet = { version = "4.1.0", package = "btwallet", default-features = false, optional = true }
 parity-scale-codec = { version = "3", optional = true, features = ["derive"] }
 futures-util = { version = "0.3", optional = true }
 

--- a/crates/btlightning/src/signing.rs
+++ b/crates/btlightning/src/signing.rs
@@ -188,7 +188,10 @@ mod tests {
             signer.keypair.ss58_address().unwrap(),
             "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
         );
-        assert_eq!(signer.sign(b"regression check").unwrap().len(), 64);
+        let message = b"regression check".to_vec();
+        let signature = signer.sign(&message).unwrap();
+        assert_eq!(signature.len(), 64);
+        assert!(signer.keypair.verify(message, signature).unwrap());
     }
 
     #[test]

--- a/crates/btlightning/src/signing.rs
+++ b/crates/btlightning/src/signing.rs
@@ -109,11 +109,9 @@ impl BtWalletSigner {
             Some(path.to_string()),
             None,
         );
-        let keypair = wallet
-            .get_hotkey(Some(hotkey_name.to_string()))
-            .map_err(|e| {
-                LightningError::Config(format!("failed to load hotkey from wallet: {}", e))
-            })?;
+        let keypair = wallet.get_hotkey(None).map_err(|e| {
+            LightningError::Config(format!("failed to load hotkey from wallet: {}", e))
+        })?;
         Ok(Self { keypair })
     }
 }
@@ -132,6 +130,9 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "btwallet")]
+    const CRYPTO_SR25519: u8 = 1;
+
+    #[cfg(feature = "btwallet")]
     #[test]
     fn from_wallet_resolves_hotkey_with_custom_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -145,7 +146,7 @@ mod tests {
             None,
         );
         wallet
-            .new_hotkey(12, false, true, true, false, None)
+            .new_hotkey(12, false, true, true, false, None, CRYPTO_SR25519)
             .unwrap();
 
         let expected_ss58 = wallet.get_hotkey(None).unwrap().ss58_address().unwrap();
@@ -163,6 +164,31 @@ mod tests {
             loaded_ss58, expected_ss58,
             "from_wallet loaded a different keypair than the one written to disk"
         );
+    }
+
+    #[cfg(feature = "btwallet")]
+    #[test]
+    fn from_wallet_loads_hotkey_carrying_integer_crypto_type() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let hotkeys = dir.path().join("testwallet").join("hotkeys");
+        std::fs::create_dir_all(&hotkeys).unwrap();
+        let mut f = std::fs::File::create(hotkeys.join("testhk")).unwrap();
+        f.write_all(
+            br#"{"secretPhrase":"bottom drive obey lake curtain smoke basket hold race lonely fit walk","cryptoType":1}"#,
+        )
+        .unwrap();
+
+        let signer =
+            BtWalletSigner::from_wallet("testwallet", &dir.path().to_string_lossy(), "testhk")
+                .expect("hotkey carrying an integer cryptoType should load");
+
+        assert_eq!(
+            signer.keypair.ss58_address().unwrap(),
+            "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
+        );
+        assert_eq!(signer.sign(b"regression check").unwrap().len(), 64);
     }
 
     #[test]


### PR DESCRIPTION
## What

Two defects in the wallet-backed signer path, both in `crates/btlightning/src/signing.rs`.

### 1. Keyfiles carrying an integer crypto type cannot be parsed

Current upstream wallet tooling writes a `cryptoType` integer into the keyfile JSON alongside the existing string fields:

```json
{"secretPhrase":"...","ss58Address":"...","cryptoType":1}
```

The pinned wallet library deserializes the whole keyfile object as a map of string values, so a single integer aborts the entire parse before any field is read, and `BtWalletSigner::from_wallet` cannot load the hotkey. Keys from older tooling omit the field and still load, which is why this only surfaced recently. The advanced revision models the keyfile as a generic JSON value and reads the crypto type properly.

### 2. The hotkey name was passed where a passphrase belongs

`from_wallet` called `get_hotkey(Some(hotkey_name))`, but that parameter carries the decryption passphrase. An encrypted hotkey was therefore offered its own filename instead of the configured secret, while the equivalent chain-side loader in `subnet-2` correctly passes none. This stayed quiet only because hotkeys are conventionally unencrypted; anyone who encrypted one would see this path fail while the miner succeeded on the same wallet. Now passes none and lets the library resolve the passphrase.

## Verification

`cargo test --locked -p btlightning --features btwallet --lib signing` passes all 8 cases, including a new one that loads a keyfile carrying `cryptoType`. `cargo fmt --check` and `cargo clippy --all-targets --features btwallet -- -D warnings` are clean.

The advanced revision widens `new_hotkey` with a seventh explicit crypto-type argument, a breaking signature change in a minor release, so the existing test call site is updated to match.

## Lockfile scope

The lock edit is a single entry. A plain `cargo update` re-shuffled roughly a dozen target-gated Windows dependency edges as a side effect, so the entry was advanced surgically instead and confirmed with `cargo check --locked`. Resolution of every other package is byte-identical. The new revision was published 2026-05-28, has no RustSec advisory, and its checksum matches crates.io.

## Release note

Version stays `0.1.0` in tree, since `release.yml` derives the published version from the tag. Reaching consumers of the published crate and the Python wheels needs a `v0.2.15` tag after merge.

## Cross-repo note

`subnet-2` carries the same dependency advance in inference-labs-inc/subnet-2#610 and does not depend on this PR: cargo unifies this dependency across the whole graph, so that repo's own lockfile governs the copy it links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet signing by correctly loading the wallet’s default hotkey and preserving existing error handling.
  * Enhanced wallet-file compatibility, including integer crypto type values, expected SS58 identity formats, 64-byte signatures, and signature validity checks.
  * Ensured hotkey creation uses the appropriate cryptographic settings for consistent signature behavior.
* **Tests**
  * Strengthened test coverage around wallet loading and signature verification.
* **Chores**
  * Updated the optional wallet dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->